### PR TITLE
Fix too many updates/chunk updates being sent. Fixed #11 and #13.

### DIFF
--- a/src/main/java/ftblag/fluidcows/block/stall/StallBlock.java
+++ b/src/main/java/ftblag/fluidcows/block/stall/StallBlock.java
@@ -40,6 +40,11 @@ public class StallBlock extends BaseBlock implements ITileEntityProvider {
         GameRegistry.registerTileEntity(StallTileEntity.class, "stall_te");
     }
 
+    @Override
+    public boolean eventReceived(IBlockState state, World worldIn, BlockPos pos, int id, int param) {
+        return worldIn.getTileEntity(pos).receiveClientEvent(id, param);
+    }
+
     public static void update(World world, BlockPos pos, boolean cow) {
         IBlockState state = world.getBlockState(pos);
         if (state.getBlock() == FluidCows.stall && state.getValue(HASCOW) != cow)

--- a/src/main/java/ftblag/fluidcows/block/stall/StallTileEntity.java
+++ b/src/main/java/ftblag/fluidcows/block/stall/StallTileEntity.java
@@ -112,8 +112,8 @@ public class StallTileEntity extends TileEntity implements IInventoryHelper, IFl
                 cd--;
                 lastSync = false;
             }
-            if (cd % 10 == 0) {
-                markDirtyClient();
+            if (fluid != null && cd != 0 && cd % 300 == 0) {
+                this.world.addBlockEvent(this.pos, this.getBlockType(), 9001, cd);
             } else if (cd == 0 && !lastSync) {
                 markDirtyClient();
                 lastSync = true;
@@ -218,6 +218,18 @@ public class StallTileEntity extends TileEntity implements IInventoryHelper, IFl
     @Override
     public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
         return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ? CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(new InvWrapper(this)) : capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY ? CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(tank) : super.getCapability(capability, facing);
+    }
+
+    @Override
+    public boolean receiveClientEvent(int id, int type) {
+        if (!this.world.isRemote)
+            return true;
+
+        if (id == 9001)
+        {
+            cd = type;
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/ftblag/fluidcows/entity/EntityFluidCow.java
+++ b/src/main/java/ftblag/fluidcows/entity/EntityFluidCow.java
@@ -38,6 +38,8 @@ public class EntityFluidCow extends EntityCowCopy implements IEntityAdditionalSp
     private static final DataParameter<Integer> CD = EntityDataManager.createKey(EntityFluidCow.class, DataSerializers.VARINT);
     public Fluid fluid = FCUtils.getRandFluid();
 
+    boolean first = true;
+
     private boolean alreadyGrowth = false;
     private int cooldown = -1;
 
@@ -73,8 +75,10 @@ public class EntityFluidCow extends EntityCowCopy implements IEntityAdditionalSp
             cooldown--;
         }
         if (!getEntityWorld().isRemote) {
-            if (cooldown % 300 == 0)
+            if (first || (cooldown != 0 && cooldown % 300 == 0)) {
                 syncCD();
+                first = false;
+            }
         }
     }
 
@@ -266,7 +270,6 @@ public class EntityFluidCow extends EntityCowCopy implements IEntityAdditionalSp
         if (tmp)
             fluid = FluidRegistry.getFluid(ByteBufUtils.readUTF8String(buffer));
         updateCD(ByteBufUtils.readVarInt(buffer, 4));
-        syncCD();
     }
 
     @Override


### PR DESCRIPTION
This alters how cooldown syncing is done - reducing how much is done, and the method it is done by to reduce chunk updates which will fix the extreme network usage and the FPS issues for some users. It is still fully compatible with HWYLA and TheOneProbe with information showing correctly.